### PR TITLE
rspec3 wants 'example' passed to the 'before' blocks

### DIFF
--- a/lib/jim/rspec/enabler.rb
+++ b/lib/jim/rspec/enabler.rb
@@ -1,5 +1,5 @@
 RSpec.configure do |config|
-  config.before(:each) do
+  config.before(:each) do |example|
     has_enabled = example.metadata.keys.include?(:enabled_features)
     enabled_features = example.metadata[:enabled_features]
 

--- a/lib/jim/version.rb
+++ b/lib/jim/version.rb
@@ -1,3 +1,3 @@
 module Jim
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
Using jim in an rspec3 based app blow up because it knows nothing of "example". This is the fix.
